### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+Lumalla is a Wayland window manager written in Rust. It is a single binary that requires Linux display/seat hardware at runtime (DRM, libseat, Vulkan). In cloud/headless VMs, compilation and tests work fully, but `cargo run` will exit immediately because no seat or `/dev/dri` device is available.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Build | `cargo build --workspace` |
+| Test | `cargo test --workspace` |
+| Lint | `cargo clippy --workspace` |
+| Format check | `cargo fmt --check` |
+| Run (with log) | `cargo run -- -l /tmp/lumalla.log` |
+
+### System dependencies
+
+The build requires `libseat-dev`, `libdrm-dev`, and `libgbm-dev` (Ubuntu packages). These are installed by the update script. `LIBCLANG_PATH` must point to the libclang `.so` directory for `bindgen` to work; it is set in `~/.bashrc` to `/usr/lib/llvm-18/lib`.
+
+### Crate workspace
+
+8 internal crates under `crates/` plus the root binary. See `Cargo.toml` workspace members for the full list. The `flake.nix` defines the canonical dev environment (Nix is not used in cloud VMs; we install apt packages instead).
+
+### Runtime limitations in cloud VMs
+
+- The binary requires DRM/KMS (`/dev/dri`) and a seat daemon (`seatd`) at runtime, so `cargo run` will fail with display/renderer errors. This is expected.
+- All unit tests, doc-tests, and integration tests pass without display hardware.
+- The `use-libseat-crate` cargo feature switches from custom FFI bindings to the `libseat` crate; default build uses custom bindings via `bindgen`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents working on this codebase.

## What's included

- Key build/test/lint/format commands
- System dependency requirements (`libseat-dev`, `libdrm-dev`, `libgbm-dev`)
- Runtime limitations in headless cloud VMs (no DRM/seat hardware)
- Workspace structure overview

## Environment setup verified

All checks pass in the cloud VM:

- **Build**: `cargo build --workspace` compiles all 8 crates + root binary
- **Tests**: `cargo test --workspace` — 31 tests pass (15 unit + 16 doc-tests)
- **Lint**: `cargo clippy --workspace` — passes (only pre-existing warnings)
- **Format**: `cargo fmt --check` — clean
- **Run**: Binary starts, parses args, exits with expected errors in headless environment

Build and test evidence:
[build_test_output.log](https://cursor.com/agents/bc-b2c872cb-145a-4717-955c-43127b6a7eb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2c872cb-145a-4717-955c-43127b6a7eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2c872cb-145a-4717-955c-43127b6a7eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

