### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Lumalla is a Wayland window manager (compositor) for Linux, built as a Rust workspace with 8 internal crates plus the root binary. It uses Nix flakes for its development environment and CI.
+
+### Development environment
+
+All build commands **must** be run inside the Nix devShell to get the correct Rust nightly toolchain and native dependencies (libseat, libdrm, libgbm, Vulkan). The update script starts the Nix daemon automatically; all you need is the `nix develop --command ...` prefix.
+
+### Common commands
+
+| Task | Command |
+|------|---------|
+| Type-check | `nix develop --command cargo check --all-targets` |
+| Format check | `nix develop --command cargo fmt --all -- --check` |
+| Tests | `nix develop --command cargo test --workspace` |
+| Build (dev) | `nix develop --command cargo build` |
+| CI-equivalent | `nix flake check --print-build-logs --show-trace` |
+| Run binary | `nix develop --command cargo run -- --help` |
+
+### Gotchas
+
+- **Edition 2024**: All crates use `edition = "2024"`, which requires Rust nightly. The system Rust toolchain (stable) will fail. Always use `nix develop --command ...` so the flake-provided nightly Rust is used.
+- **Clippy**: The Nix devShell does not include `clippy`. Running `cargo clippy` inside `nix develop` will fall through to the system stable clippy, which cannot compile edition 2024 code. CI does not run clippy.
+- **Nix daemon**: The update script starts `nix-daemon` in the background. If `nix develop` fails with a socket error, verify the daemon is running: `pgrep nix-daemon || (sudo nix-daemon &)`.
+- **No GUI testing**: Lumalla is a Wayland compositor that requires DRM/KMS hardware access. It cannot be launched inside a Cloud Agent VM. Testing is limited to `cargo check`, `cargo test`, `cargo build`, and `nix flake check`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `AGENTS.md` documenting the Nix devShell-based development workflow for Cursor Cloud agents.

## What's included

- Overview of the Lumalla Rust workspace
- Table of common development commands (`cargo check`, `cargo test`, `cargo build`, `cargo fmt`, `nix flake check`)
- Non-obvious gotchas:
  - Edition 2024 requires Rust nightly (only available via the Nix devShell)
  - `clippy` is not provided by the Nix devShell and CI doesn't run it
  - `nix-daemon` must be running for `nix develop` to work
  - No GUI testing possible (Wayland compositor requires DRM/KMS hardware)

## Verification

All commands verified in Cloud Agent VM:

- `nix develop --command cargo check --all-targets` — passed
- `nix develop --command cargo fmt --all -- --check` — passed (clean)
- `nix develop --command cargo test --workspace` — 31 tests passed (15 unit + 16 doc-tests)
- `nix develop --command cargo build` — binary built successfully
- `nix develop --command cargo run -- --help` — binary runs, shows usage
- `nix flake check --print-build-logs --show-trace` — all checks passed

Test output:
[cargo_test_output.log](https://cursor.com/agents/bc-35e4c823-180c-4f4b-a27d-3e0affb54172/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcargo_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35e4c823-180c-4f4b-a27d-3e0affb54172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35e4c823-180c-4f4b-a27d-3e0affb54172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

